### PR TITLE
Fix contact info class selector name

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1196,7 +1196,7 @@ form button:hover {
   color: whitesmoke;
   padding: 30px;
 }
-.contect-info-content-line {
+.contact-info-content-line {
   height: auto;
   padding: 10px;
   position: relative;
@@ -1789,7 +1789,7 @@ For devices with smaller width like mobile phone
     color: whitesmoke;
     padding: 20px;
   }
-  .contect-info-content-line {
+  .contact-info-content-line {
     height: auto;
     padding: 10px;
     position: relative;
@@ -2268,7 +2268,7 @@ for tabs and large phones
     color: whitesmoke;
     padding: 20px;
   }
-  .contect-info-content-line {
+  .contact-info-content-line {
     height: auto;
     padding: 10px;
     position: relative;

--- a/index.html
+++ b/index.html
@@ -611,7 +611,7 @@
                         Contact Info
                     </div>
                     <div class="contact-info-content">
-                        <div class="contect-info-content-line">
+                        <div class="contact-info-content-line">
                             <a href="https://wa.me/13058097439" target="_blank"><img
                                     src="./images/whatsapp logo alt.png" class="icon" alt="whatsapp-icon">
                             </a>
@@ -623,14 +623,14 @@
                                 </a>
                             </div>
                         </div>
-                        <div class="contect-info-content-line">
+                        <div class="contact-info-content-line">
                             <img src="./images/icon-location.png" class="icon" alt="location-icon">
                             <div class="contact-info-icon-text">
                                 <h6>Location</h6>
                                 <p>Miami, USA - Buenos Aires, ARG</p>
                             </div>
                         </div>
-                        <div class="contect-info-content-line">
+                        <div class="contact-info-content-line">
                             <img src="./images/icon-phone.png" class="icon" alt="phone-icon">
                             <div class="contact-info-icon-text">
                                 <h6>Call</h6>
@@ -641,7 +641,7 @@
                             </div>
                         </div>
 
-                        <div class="contect-info-content-line">
+                        <div class="contact-info-content-line">
                             <a href="mailto:hello@digital-dino.com" target="_blank"
                                 style="color: inherit; text-decoration: none">
                                 <img src="./images/icon-email.png" class="icon" alt="email-icon">


### PR DESCRIPTION
## Summary
- fix typos in contact info class names in `index.html`
- rename CSS selectors from `.contect-info-content-line` to `.contact-info-content-line`

## Testing
- `grep -n "contact-info-content-line" -n index.html`
- `grep -n "contact-info-content-line" -n css/index.css`
