### PR TITLE
Remove console log and ensure newline

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -14,7 +14,6 @@ $(function(){
 $('.colors a').on("click",function(e) {
   e.preventDefault();
   var attr = $(this).attr("title");
-  console.log(attr);
   var colorLink = $("#theme-color");
   if(colorLink.length){
     colorLink.attr('href', 'css/' + attr + '.css');


### PR DESCRIPTION
## Summary
- remove leftover `console.log(attr)` in `js/index.js`
- ensure `js/index.js` ends with a newline

## Testing
- `pytest -q` *(fails: command not found)*