### PR TITLE
Fix closing tag for contact info

### DIFF
--- a/index.html
+++ b/index.html
@@ -644,6 +644,7 @@
                                 <div class="contact-info-icon-text">
                                     <h6>Email</h6>
                                     <p>hello@digital-dino.com</p>
+                                </div>
                             </a>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- close `contact-info-icon-text` div before closing the anchor tag

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*